### PR TITLE
remove debug log line

### DIFF
--- a/rcon.go
+++ b/rcon.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"log"
 	"net"
 	"time"
 )
@@ -38,7 +37,6 @@ type RCONHeader struct {
 }
 
 func (c *MCConn) Open(addr, password string) error {
-	log.Println("Dial " + addr)
 	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
 	if err != nil {
 		return err


### PR DESCRIPTION
shouldn't be logging in a library... or at least allow the user to pass in a logger? just trying to clean up my logs